### PR TITLE
Skip logging of large lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-tests/data
-tests/batch_transform.py

--- a/sagemaker_shim/models.py
+++ b/sagemaker_shim/models.py
@@ -339,7 +339,14 @@ class InferenceTask(BaseModel):
             return
 
         while True:
-            line = await stream.readline()
+            try:
+                line = await stream.readline()
+            except ValueError:
+                self.log_external(
+                    level=logging.WARNING,
+                    msg="WARNING: A log line was skipped as it was too long",
+                )
+                continue
 
             if not line:
                 break


### PR DESCRIPTION
Lines that are longer than `2 ** 16` cause an error with asyncio. This PR fixes the crash by skipping the line as it is not something we really want users to log anyway.