### PR TITLE
Fix CI by pinning to ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         run: pre-commit run --all-files
 
   build:
+    # Must use ubuntu 22 in order to use deadsnakes python 3.12
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +55,7 @@ jobs:
   deploy:
     if: github.event_name == 'release'
     needs: [precommit, build]
+    # Must use ubuntu 22 in order to use deadsnakes python 3.12
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Python ${{ env.PYTHON_VERSION }}
         # deadsnakes python required due to https://github.com/JonathonReinhart/staticx/issues/188
-        uses: deadsnakes/action@v3.1.0
+        uses: deadsnakes/action@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: pre-commit run --all-files
 
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python ${{ env.PYTHON_VERSION }}
@@ -54,7 +54,7 @@ jobs:
   deploy:
     if: github.event_name == 'release'
     needs: [precommit, build]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Python ${{ env.PYTHON_VERSION }}
-        # deadsnakes python required due to https://github.com/JonathonReinhart/staticx/issues/188
-        uses: deadsnakes/action@v3.2.0
+      - name: Install Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
@@ -57,9 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Python ${{ env.PYTHON_VERSION }}
-        # deadsnakes python required due to https://github.com/JonathonReinhart/staticx/issues/188
-        uses: deadsnakes/action@v3.2.0
+      - name: Install Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Python ${{ env.PYTHON_VERSION }}
         # deadsnakes python required due to https://github.com/JonathonReinhart/staticx/issues/188
-        uses: deadsnakes/action@v3
+        uses: deadsnakes/action@v3.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Python ${{ env.PYTHON_VERSION }}
         # deadsnakes python required due to https://github.com/JonathonReinhart/staticx/issues/188
-        uses: deadsnakes/action@v3
+        uses: deadsnakes/action@v3.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Python ${{ env.PYTHON_VERSION }}
         # deadsnakes python required due to https://github.com/JonathonReinhart/staticx/issues/188
-        uses: deadsnakes/action@v3.1.0
+        uses: deadsnakes/action@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,12 @@ jobs:
         run: pre-commit run --all-files
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v5
+      - name: Setup Python ${{ env.PYTHON_VERSION }}
+        # deadsnakes python required due to https://github.com/JonathonReinhart/staticx/issues/188
+        uses: deadsnakes/action@v3.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
@@ -53,11 +54,12 @@ jobs:
   deploy:
     if: github.event_name == 'release'
     needs: [precommit, build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v5
+      - name: Setup Python ${{ env.PYTHON_VERSION }}
+        # deadsnakes python required due to https://github.com/JonathonReinhart/staticx/issues/188
+        uses: deadsnakes/action@v3.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies

--- a/tests/test_patch_image.py
+++ b/tests/test_patch_image.py
@@ -63,20 +63,26 @@ def test_patch_image(registry):
 
     config = get_image_config(repo_tag=repo_tag)
     env_vars = get_new_env_vars(existing_config=config)
-    new_tag = mutate_image(
-        repo_tag=repo_tag, env_vars=env_vars, version=__version__
-    )
-    new_config = get_image_config(repo_tag=new_tag)
 
+    assert set(config["config"]["Env"]) == {
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    }
     assert env_vars == {
         "GRAND_CHALLENGE_COMPONENT_CMD_B64J": "WyJzaCJd",
         "GRAND_CHALLENGE_COMPONENT_ENTRYPOINT_B64J": "bnVsbA==",
         "GRAND_CHALLENGE_COMPONENT_USER": "0:0",
     }
+
+    new_tag = mutate_image(
+        repo_tag=repo_tag, env_vars=env_vars, version=__version__
+    )
+    new_config = get_image_config(repo_tag=new_tag)
+
     assert new_config["config"]["Entrypoint"] == ["/sagemaker-shim"]
     assert "Cmd" not in new_config["config"]
     assert set(new_config["config"]["Env"]) == {
         "GRAND_CHALLENGE_COMPONENT_CMD_B64J=WyJzaCJd",
         "GRAND_CHALLENGE_COMPONENT_ENTRYPOINT_B64J=bnVsbA==",
         "GRAND_CHALLENGE_COMPONENT_USER=0:0",
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     }


### PR DESCRIPTION
Deadsnakes python needs to be used in order for staticx to work, and deadsnakes does not provide python 3.12 on ubuntu 24.04, so pin to 22.04.

Closes #37 