### PR TITLE
Remove need for log parsing on errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ These structured logs are JSON objects with the format:
   "source": "stdout" | "stderr",   // The source stream
   "internal": true | false,  // Whether the source of the log is from sagemaker shim or the subprocess
   "task": "" | null,  // The ID of the task
-  "inference_result_skipped": true | false,  // (Optional) Whether output of the inference result has been skipped
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "botocore",
 ]
 name = "sagemaker-shim"
-version = "0.7.0"
+version = "0.8.0"
 description = "Adapts algorithms that implement the Grand Challenge inference API for running in SageMaker"
 readme = "README.md"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "botocore",
 ]
 name = "sagemaker-shim"
-version = "0.8.0"
+version = "0.8.0a1"
 description = "Adapts algorithms that implement the Grand Challenge inference API for running in SageMaker"
 readme = "README.md"
 classifiers = [

--- a/sagemaker_shim/app.py
+++ b/sagemaker_shim/app.py
@@ -17,6 +17,7 @@ Notes:
   - /opt/ml/model will contain the model weights, this can be an empty .tar.gz file
 """
 
+import asyncio
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -28,8 +29,10 @@ from sagemaker_shim.models import (
     AuxiliaryData,
     InferenceResult,
     InferenceTask,
+    RuntimeSetupResult,
     UserProcess,
     get_s3_resources,
+    upload_runtime_setup_result,
 )
 
 logger = logging.getLogger(__name__)
@@ -50,6 +53,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             await auxiliary_data.setup()
         except UserSafeError as error:
             logger.error(msg=str(error), extra={"internal": False})
+            await asyncio.shield(
+                upload_runtime_setup_result(
+                    runtime_setup_result=RuntimeSetupResult(
+                        return_code=1,
+                        error_message=str(error),
+                    ),
+                    s3_resources=s3_resources,
+                )
+            )
             # If subprocess errors are handled our process should exit cleanly
             raise SystemExit(0) from error
 
@@ -57,8 +69,24 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             await USER_PROCESS.setup()
         except UserSafeError as error:
             logger.error(msg=str(error), extra={"internal": False})
+            await asyncio.shield(
+                upload_runtime_setup_result(
+                    runtime_setup_result=RuntimeSetupResult(
+                        return_code=1,
+                        error_message=str(error),
+                    ),
+                    s3_resources=s3_resources,
+                )
+            )
             # If subprocess errors are handled our process should exit cleanly
             raise SystemExit(0) from error
+
+        await asyncio.shield(
+            upload_runtime_setup_result(
+                runtime_setup_result=RuntimeSetupResult(return_code=0),
+                s3_resources=s3_resources,
+            )
+        )
 
         try:
             yield

--- a/sagemaker_shim/app.py
+++ b/sagemaker_shim/app.py
@@ -49,20 +49,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         try:
             await auxiliary_data.setup()
         except UserSafeError as error:
-            logger.error(
-                msg=str(error),
-                extra={"internal": False, "inference_result_skipped": True},
-            )
+            logger.error(msg=str(error), extra={"internal": False})
             # If subprocess errors are handled our process should exit cleanly
             raise SystemExit(0) from error
 
         try:
             await USER_PROCESS.setup()
         except UserSafeError as error:
-            logger.error(
-                msg=str(error),
-                extra={"internal": False, "inference_result_skipped": True},
-            )
+            logger.error(msg=str(error), extra={"internal": False})
             # If subprocess errors are handled our process should exit cleanly
             raise SystemExit(0) from error
 

--- a/sagemaker_shim/app.py
+++ b/sagemaker_shim/app.py
@@ -53,7 +53,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         except UserSafeError as error:
             logger.error(msg=str(error), extra={"internal": False})
             runtime_setup_result = RuntimeSetupResult(
-                return_code=1, error_message=str(error)
+                return_code=1, user_safe_error_message=str(error)
             )
             await asyncio.shield(
                 runtime_setup_result.upload(s3_resources=s3_resources)
@@ -66,7 +66,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         except UserSafeError as error:
             logger.error(msg=str(error), extra={"internal": False})
             runtime_setup_result = RuntimeSetupResult(
-                return_code=1, error_message=str(error)
+                return_code=1, user_safe_error_message=str(error)
             )
             await asyncio.shield(
                 runtime_setup_result.upload(s3_resources=s3_resources)

--- a/sagemaker_shim/app.py
+++ b/sagemaker_shim/app.py
@@ -32,7 +32,6 @@ from sagemaker_shim.models import (
     RuntimeSetupResult,
     UserProcess,
     get_s3_resources,
-    upload_runtime_setup_result,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,14 +52,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             await auxiliary_data.setup()
         except UserSafeError as error:
             logger.error(msg=str(error), extra={"internal": False})
+            runtime_setup_result = RuntimeSetupResult(
+                return_code=1, error_message=str(error)
+            )
             await asyncio.shield(
-                upload_runtime_setup_result(
-                    runtime_setup_result=RuntimeSetupResult(
-                        return_code=1,
-                        error_message=str(error),
-                    ),
-                    s3_resources=s3_resources,
-                )
+                runtime_setup_result.upload(s3_resources=s3_resources)
             )
             # If subprocess errors are handled our process should exit cleanly
             raise SystemExit(0) from error
@@ -69,23 +65,18 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             await USER_PROCESS.setup()
         except UserSafeError as error:
             logger.error(msg=str(error), extra={"internal": False})
+            runtime_setup_result = RuntimeSetupResult(
+                return_code=1, error_message=str(error)
+            )
             await asyncio.shield(
-                upload_runtime_setup_result(
-                    runtime_setup_result=RuntimeSetupResult(
-                        return_code=1,
-                        error_message=str(error),
-                    ),
-                    s3_resources=s3_resources,
-                )
+                runtime_setup_result.upload(s3_resources=s3_resources)
             )
             # If subprocess errors are handled our process should exit cleanly
             raise SystemExit(0) from error
 
+        runtime_setup_result = RuntimeSetupResult(return_code=0)
         await asyncio.shield(
-            upload_runtime_setup_result(
-                runtime_setup_result=RuntimeSetupResult(return_code=0),
-                s3_resources=s3_resources,
-            )
+            runtime_setup_result.upload(s3_resources=s3_resources)
         )
 
         try:

--- a/sagemaker_shim/cli.py
+++ b/sagemaker_shim/cli.py
@@ -98,7 +98,7 @@ async def invoke(tasks: str, file: str) -> None:
             except UserSafeError as error:
                 logger.error(msg=str(error), extra={"internal": False})
                 runtime_setup_result = RuntimeSetupResult(
-                    return_code=1, error_message=str(error)
+                    return_code=1, user_safe_error_message=str(error)
                 )
                 await asyncio.shield(
                     runtime_setup_result.upload(s3_resources=s3_resources)
@@ -111,7 +111,7 @@ async def invoke(tasks: str, file: str) -> None:
             except UserSafeError as error:
                 logger.error(msg=str(error), extra={"internal": False})
                 runtime_setup_result = RuntimeSetupResult(
-                    return_code=1, error_message=str(error)
+                    return_code=1, user_safe_error_message=str(error)
                 )
                 await asyncio.shield(
                     runtime_setup_result.upload(s3_resources=s3_resources)

--- a/sagemaker_shim/cli.py
+++ b/sagemaker_shim/cli.py
@@ -19,10 +19,12 @@ from sagemaker_shim.logging import LOGGING_CONFIG
 from sagemaker_shim.models import (
     AuxiliaryData,
     InferenceTaskList,
+    RuntimeSetupResult,
     S3Resources,
     UserProcess,
     get_s3_file_content,
     get_s3_resources,
+    upload_runtime_setup_result,
 )
 
 logger = logging.getLogger(__name__)
@@ -96,6 +98,15 @@ async def invoke(tasks: str, file: str) -> None:
                 await auxiliary_data.setup()
             except UserSafeError as error:
                 logger.error(msg=str(error), extra={"internal": False})
+                await asyncio.shield(
+                    upload_runtime_setup_result(
+                        runtime_setup_result=RuntimeSetupResult(
+                            return_code=1,
+                            error_message=str(error),
+                        ),
+                        s3_resources=s3_resources,
+                    )
+                )
                 # If subprocess errors are handled our process should exit cleanly
                 raise SystemExit(0) from error
 
@@ -103,8 +114,24 @@ async def invoke(tasks: str, file: str) -> None:
                 await user_process.setup()
             except UserSafeError as error:
                 logger.error(msg=str(error), extra={"internal": False})
+                await asyncio.shield(
+                    upload_runtime_setup_result(
+                        runtime_setup_result=RuntimeSetupResult(
+                            return_code=1,
+                            error_message=str(error),
+                        ),
+                        s3_resources=s3_resources,
+                    )
+                )
                 # If subprocess errors are handled our process should exit cleanly
                 raise SystemExit(0) from error
+
+            await asyncio.shield(
+                upload_runtime_setup_result(
+                    runtime_setup_result=RuntimeSetupResult(return_code=0),
+                    s3_resources=s3_resources,
+                )
+            )
 
             for task in parsed_tasks.root:
                 # Only run one task at a time

--- a/sagemaker_shim/cli.py
+++ b/sagemaker_shim/cli.py
@@ -95,26 +95,14 @@ async def invoke(tasks: str, file: str) -> None:
             try:
                 await auxiliary_data.setup()
             except UserSafeError as error:
-                logger.error(
-                    msg=str(error),
-                    extra={
-                        "internal": False,
-                        "inference_result_skipped": True,
-                    },
-                )
+                logger.error(msg=str(error), extra={"internal": False})
                 # If subprocess errors are handled our process should exit cleanly
                 raise SystemExit(0) from error
 
             try:
                 await user_process.setup()
             except UserSafeError as error:
-                logger.error(
-                    msg=str(error),
-                    extra={
-                        "internal": False,
-                        "inference_result_skipped": True,
-                    },
-                )
+                logger.error(msg=str(error), extra={"internal": False})
                 # If subprocess errors are handled our process should exit cleanly
                 raise SystemExit(0) from error
 

--- a/sagemaker_shim/cli.py
+++ b/sagemaker_shim/cli.py
@@ -24,7 +24,6 @@ from sagemaker_shim.models import (
     UserProcess,
     get_s3_file_content,
     get_s3_resources,
-    upload_runtime_setup_result,
 )
 
 logger = logging.getLogger(__name__)
@@ -98,14 +97,11 @@ async def invoke(tasks: str, file: str) -> None:
                 await auxiliary_data.setup()
             except UserSafeError as error:
                 logger.error(msg=str(error), extra={"internal": False})
+                runtime_setup_result = RuntimeSetupResult(
+                    return_code=1, error_message=str(error)
+                )
                 await asyncio.shield(
-                    upload_runtime_setup_result(
-                        runtime_setup_result=RuntimeSetupResult(
-                            return_code=1,
-                            error_message=str(error),
-                        ),
-                        s3_resources=s3_resources,
-                    )
+                    runtime_setup_result.upload(s3_resources=s3_resources)
                 )
                 # If subprocess errors are handled our process should exit cleanly
                 raise SystemExit(0) from error
@@ -114,23 +110,18 @@ async def invoke(tasks: str, file: str) -> None:
                 await user_process.setup()
             except UserSafeError as error:
                 logger.error(msg=str(error), extra={"internal": False})
+                runtime_setup_result = RuntimeSetupResult(
+                    return_code=1, error_message=str(error)
+                )
                 await asyncio.shield(
-                    upload_runtime_setup_result(
-                        runtime_setup_result=RuntimeSetupResult(
-                            return_code=1,
-                            error_message=str(error),
-                        ),
-                        s3_resources=s3_resources,
-                    )
+                    runtime_setup_result.upload(s3_resources=s3_resources)
                 )
                 # If subprocess errors are handled our process should exit cleanly
                 raise SystemExit(0) from error
 
+            runtime_setup_result = RuntimeSetupResult(return_code=0)
             await asyncio.shield(
-                upload_runtime_setup_result(
-                    runtime_setup_result=RuntimeSetupResult(return_code=0),
-                    s3_resources=s3_resources,
-                )
+                runtime_setup_result.upload(s3_resources=s3_resources)
             )
 
             for task in parsed_tasks.root:

--- a/sagemaker_shim/logging.py
+++ b/sagemaker_shim/logging.py
@@ -29,11 +29,6 @@ class JSONFormatter(logging.Formatter):
 
         internal = getattr(record, "internal", True)
         task_pk = getattr(record, "task_pk", None)
-        extra_kwargs = {}
-        if hasattr(record, "inference_result_skipped"):
-            extra_kwargs["inference_result_skipped"] = (
-                record.inference_result_skipped
-            )
 
         return "\n".join(
             json.dumps(
@@ -43,7 +38,6 @@ class JSONFormatter(logging.Formatter):
                     "source": source,
                     "internal": internal,
                     "task": task_pk,
-                    **extra_kwargs,
                 }
             )
             for m in message.splitlines()

--- a/sagemaker_shim/models.py
+++ b/sagemaker_shim/models.py
@@ -1220,8 +1220,6 @@ class InferenceTask(BaseModel):
                 outputs = await self.upload_output(s3_resources=s3_resources)
             else:
                 outputs = set()
-                if not error_message:
-                    error_message = "Process returned non-zero exit code"
 
             return InferenceResult(
                 pk=self.pk,

--- a/sagemaker_shim/models.py
+++ b/sagemaker_shim/models.py
@@ -530,6 +530,7 @@ class InferenceResult(BaseModel):
 
     pk: str
     return_code: int
+    error_message: str = ""
     exec_duration: timedelta | None
     invoke_duration: timedelta | None
     outputs: list[InferenceIO]
@@ -1119,6 +1120,7 @@ class InferenceTask(BaseModel):
                 inference_result = InferenceResult(
                     pk=self.pk,
                     return_code=1,
+                    error_message=str(exception_group.exceptions[-1]),
                     outputs=[],
                     exec_duration=None,
                     invoke_duration=None,
@@ -1147,15 +1149,17 @@ class InferenceTask(BaseModel):
 
             start = time.monotonic()
 
+            error_message = ""
             try:
                 return_code = await asyncio.wait_for(
                     user_process.run_inference(task=self),
                     timeout=self.timeout.total_seconds(),
                 )
             except TimeoutError:
+                error_message = "Time limit exceeded"
                 log_external(
                     level=logging.ERROR,
-                    msg="Time limit exceeded",
+                    msg=error_message,
                     task_pk=self.pk,
                 )
                 return_code = 1
@@ -1168,10 +1172,13 @@ class InferenceTask(BaseModel):
                 outputs = await self.upload_output(s3_resources=s3_resources)
             else:
                 outputs = set()
+                if not error_message:
+                    error_message = "Process returned non-zero exit code"
 
             return InferenceResult(
                 pk=self.pk,
                 return_code=return_code,
+                error_message=error_message,
                 outputs=outputs,
                 exec_duration=(
                     timedelta(seconds=duration)

--- a/sagemaker_shim/models.py
+++ b/sagemaker_shim/models.py
@@ -1168,7 +1168,7 @@ class InferenceTask(BaseModel):
                 inference_result = InferenceResult(
                     pk=self.pk,
                     return_code=1,
-                    error_message=str(exception_group.exceptions[-1]),
+                    error_message=str(exception_group),
                     outputs=[],
                     exec_duration=None,
                     invoke_duration=None,

--- a/sagemaker_shim/models.py
+++ b/sagemaker_shim/models.py
@@ -243,6 +243,50 @@ def parse_s3_uri(*, s3_uri: str) -> S3File:
     return S3File(bucket=match.group("bucket"), key=match.group("key"))
 
 
+class RuntimeSetupResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    return_code: int
+    error_message: str = ""
+    sagemaker_shim_version: str = version("sagemaker-shim")
+
+
+async def upload_runtime_setup_result(
+    *, runtime_setup_result: RuntimeSetupResult, s3_resources: S3Resources
+) -> None:
+    content = runtime_setup_result.model_dump_json().encode("utf-8")
+    signature = hmac.new(
+        key=bytes.fromhex(
+            os.environ.get("GRAND_CHALLENGE_COMPONENT_SIGNING_KEY_HEX", "")
+        ),
+        msg=content,
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+
+    output_bucket_name = os.environ.get(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME", ""
+    )
+    output_prefix = os.environ.get(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", ""
+    )
+    bucket_key = f"{output_prefix}.sagemaker_shim/runtime_setup_result.json"
+
+    logger.info(
+        f"Uploading {bucket_key=} in "
+        f"{output_bucket_name=} with {runtime_setup_result=}"
+    )
+
+    async with s3_resources.semaphore:
+        await s3_resources.client.upload_fileobj(
+            Fileobj=io.BytesIO(content),
+            Bucket=output_bucket_name,
+            Key=bucket_key,
+            ExtraArgs={
+                "Metadata": {"signature_hmac_sha256": signature},
+            },
+        )
+
+
 async def get_s3_file_content(
     *, s3_uri: str, s3_resources: S3Resources
 ) -> bytes:

--- a/sagemaker_shim/models.py
+++ b/sagemaker_shim/models.py
@@ -29,7 +29,7 @@ from zipfile import BadZipFile
 import aioboto3
 import httpx
 from botocore.config import Config
-from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator
+from pydantic import BaseModel, ConfigDict, RootModel, field_validator
 
 from sagemaker_shim.exceptions import UserSafeError
 from sagemaker_shim.extract import safe_extract
@@ -248,38 +248,7 @@ class RuntimeSetupResult(BaseModel):
 
     return_code: int
     error_message: str = ""
-    output_bucket_name: str = Field(
-        default_factory=lambda: os.environ.get(
-            "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME", ""
-        ),
-        validate_default=True,
-    )
-    output_prefix: str = Field(
-        default_factory=lambda: os.environ.get(
-            "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", ""
-        ),
-        validate_default=True,
-    )
     sagemaker_shim_version: str = version("sagemaker-shim")
-
-    @field_validator("output_prefix")
-    @classmethod
-    def validate_prefix(cls, v: str) -> str:
-        if not v:
-            raise ValueError("Prefix cannot be blank")
-
-        if v[-1] != "/":
-            v += "/"
-
-        return v
-
-    @field_validator("output_bucket_name")
-    @classmethod
-    def validate_bucket_name(cls, v: str) -> str:
-        if not v:
-            raise ValueError("Bucket name cannot be blank")
-
-        return v
 
 
 async def upload_runtime_setup_result(
@@ -294,20 +263,23 @@ async def upload_runtime_setup_result(
         digestmod=hashlib.sha256,
     ).hexdigest()
 
-    bucket_key = (
-        f"{runtime_setup_result.output_prefix}.sagemaker_shim/"
-        f"runtime_setup_result.json"
+    output_bucket_name = os.environ.get(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME", ""
     )
+    output_prefix = os.environ.get(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", ""
+    )
+    bucket_key = f"{output_prefix}.sagemaker_shim/runtime_setup_result.json"
 
     logger.info(
         f"Uploading {bucket_key=} in "
-        f"{runtime_setup_result.output_bucket_name=} with {runtime_setup_result=}"
+        f"{output_bucket_name=} with {runtime_setup_result=}"
     )
 
     async with s3_resources.semaphore:
         await s3_resources.client.upload_fileobj(
             Fileobj=io.BytesIO(content),
-            Bucket=runtime_setup_result.output_bucket_name,
+            Bucket=output_bucket_name,
             Key=bucket_key,
             ExtraArgs={
                 "Metadata": {"signature_hmac_sha256": signature},

--- a/sagemaker_shim/models.py
+++ b/sagemaker_shim/models.py
@@ -269,6 +269,10 @@ async def upload_runtime_setup_result(
     output_prefix = os.environ.get(
         "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", ""
     )
+
+    if output_prefix[-1] != "/":
+        output_prefix += "/"
+
     bucket_key = f"{output_prefix}.sagemaker_shim/runtime_setup_result.json"
 
     logger.info(

--- a/sagemaker_shim/models.py
+++ b/sagemaker_shim/models.py
@@ -247,7 +247,7 @@ class RuntimeSetupResult(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     return_code: int
-    error_message: str = ""
+    user_safe_error_message: str = ""
     sagemaker_shim_version: str = version("sagemaker-shim")
 
     async def upload(self, *, s3_resources: S3Resources) -> None:
@@ -576,7 +576,7 @@ class InferenceResult(BaseModel):
 
     pk: str
     return_code: int
-    error_message: str = ""
+    user_safe_error_message: str = ""
     exec_duration: timedelta | None
     invoke_duration: timedelta | None
     outputs: list[InferenceIO]
@@ -1166,7 +1166,7 @@ class InferenceTask(BaseModel):
                 inference_result = InferenceResult(
                     pk=self.pk,
                     return_code=1,
-                    error_message=str(exception_group),
+                    user_safe_error_message=str(exception_group),
                     outputs=[],
                     exec_duration=None,
                     invoke_duration=None,
@@ -1195,17 +1195,17 @@ class InferenceTask(BaseModel):
 
             start = time.monotonic()
 
-            error_message = ""
+            user_safe_error_message = ""
             try:
                 return_code = await asyncio.wait_for(
                     user_process.run_inference(task=self),
                     timeout=self.timeout.total_seconds(),
                 )
             except TimeoutError:
-                error_message = "Time limit exceeded"
+                user_safe_error_message = "Time limit exceeded"
                 log_external(
                     level=logging.ERROR,
-                    msg=error_message,
+                    msg=user_safe_error_message,
                     task_pk=self.pk,
                 )
                 return_code = 1
@@ -1222,7 +1222,7 @@ class InferenceTask(BaseModel):
             return InferenceResult(
                 pk=self.pk,
                 return_code=return_code,
-                error_message=error_message,
+                user_safe_error_message=user_safe_error_message,
                 outputs=outputs,
                 exec_duration=(
                     timedelta(seconds=duration)

--- a/sagemaker_shim/models.py
+++ b/sagemaker_shim/models.py
@@ -263,9 +263,9 @@ async def upload_runtime_setup_result(
         digestmod=hashlib.sha256,
     ).hexdigest()
 
-    output_bucket_name = os.environ[
-        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME"
-    ]
+    output_bucket_name = validate_bucket_name(
+        os.environ["GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME"]
+    )
     output_prefix = os.environ[
         "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX"
     ]

--- a/sagemaker_shim/models.py
+++ b/sagemaker_shim/models.py
@@ -250,45 +250,43 @@ class RuntimeSetupResult(BaseModel):
     error_message: str = ""
     sagemaker_shim_version: str = version("sagemaker-shim")
 
+    async def upload(self, *, s3_resources: S3Resources) -> None:
+        content = self.model_dump_json().encode("utf-8")
+        signature = hmac.new(
+            key=bytes.fromhex(
+                os.environ.get("GRAND_CHALLENGE_COMPONENT_SIGNING_KEY_HEX", "")
+            ),
+            msg=content,
+            digestmod=hashlib.sha256,
+        ).hexdigest()
 
-async def upload_runtime_setup_result(
-    *, runtime_setup_result: RuntimeSetupResult, s3_resources: S3Resources
-) -> None:
-    content = runtime_setup_result.model_dump_json().encode("utf-8")
-    signature = hmac.new(
-        key=bytes.fromhex(
-            os.environ.get("GRAND_CHALLENGE_COMPONENT_SIGNING_KEY_HEX", "")
-        ),
-        msg=content,
-        digestmod=hashlib.sha256,
-    ).hexdigest()
-
-    output_bucket_name = validate_bucket_name(
-        os.environ["GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME"]
-    )
-    output_prefix = os.environ[
-        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX"
-    ]
-
-    if output_prefix[-1] != "/":
-        output_prefix += "/"
-
-    bucket_key = f"{output_prefix}.sagemaker_shim/runtime_setup_result.json"
-
-    logger.info(
-        f"Uploading {bucket_key=} in "
-        f"{output_bucket_name=} with {runtime_setup_result=}"
-    )
-
-    async with s3_resources.semaphore:
-        await s3_resources.client.upload_fileobj(
-            Fileobj=io.BytesIO(content),
-            Bucket=output_bucket_name,
-            Key=bucket_key,
-            ExtraArgs={
-                "Metadata": {"signature_hmac_sha256": signature},
-            },
+        output_bucket_name = validate_bucket_name(
+            os.environ["GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME"]
         )
+        output_prefix = os.environ[
+            "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX"
+        ]
+
+        if output_prefix[-1] != "/":
+            output_prefix += "/"
+
+        bucket_key = (
+            f"{output_prefix}.sagemaker_shim/runtime_setup_result.json"
+        )
+
+        logger.info(
+            f"Uploading {bucket_key=} in {output_bucket_name=} with {self}"
+        )
+
+        async with s3_resources.semaphore:
+            await s3_resources.client.upload_fileobj(
+                Fileobj=io.BytesIO(content),
+                Bucket=output_bucket_name,
+                Key=bucket_key,
+                ExtraArgs={
+                    "Metadata": {"signature_hmac_sha256": signature},
+                },
+            )
 
 
 async def get_s3_file_content(

--- a/sagemaker_shim/models.py
+++ b/sagemaker_shim/models.py
@@ -29,7 +29,7 @@ from zipfile import BadZipFile
 import aioboto3
 import httpx
 from botocore.config import Config
-from pydantic import BaseModel, ConfigDict, RootModel, field_validator
+from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator
 
 from sagemaker_shim.exceptions import UserSafeError
 from sagemaker_shim.extract import safe_extract
@@ -248,7 +248,38 @@ class RuntimeSetupResult(BaseModel):
 
     return_code: int
     error_message: str = ""
+    output_bucket_name: str = Field(
+        default_factory=lambda: os.environ.get(
+            "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME", ""
+        ),
+        validate_default=True,
+    )
+    output_prefix: str = Field(
+        default_factory=lambda: os.environ.get(
+            "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", ""
+        ),
+        validate_default=True,
+    )
     sagemaker_shim_version: str = version("sagemaker-shim")
+
+    @field_validator("output_prefix")
+    @classmethod
+    def validate_prefix(cls, v: str) -> str:
+        if not v:
+            raise ValueError("Prefix cannot be blank")
+
+        if v[-1] != "/":
+            v += "/"
+
+        return v
+
+    @field_validator("output_bucket_name")
+    @classmethod
+    def validate_bucket_name(cls, v: str) -> str:
+        if not v:
+            raise ValueError("Bucket name cannot be blank")
+
+        return v
 
 
 async def upload_runtime_setup_result(
@@ -263,23 +294,20 @@ async def upload_runtime_setup_result(
         digestmod=hashlib.sha256,
     ).hexdigest()
 
-    output_bucket_name = os.environ.get(
-        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME", ""
+    bucket_key = (
+        f"{runtime_setup_result.output_prefix}.sagemaker_shim/"
+        f"runtime_setup_result.json"
     )
-    output_prefix = os.environ.get(
-        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", ""
-    )
-    bucket_key = f"{output_prefix}.sagemaker_shim/runtime_setup_result.json"
 
     logger.info(
         f"Uploading {bucket_key=} in "
-        f"{output_bucket_name=} with {runtime_setup_result=}"
+        f"{runtime_setup_result.output_bucket_name=} with {runtime_setup_result=}"
     )
 
     async with s3_resources.semaphore:
         await s3_resources.client.upload_fileobj(
             Fileobj=io.BytesIO(content),
-            Bucket=output_bucket_name,
+            Bucket=runtime_setup_result.output_bucket_name,
             Key=bucket_key,
             ExtraArgs={
                 "Metadata": {"signature_hmac_sha256": signature},

--- a/sagemaker_shim/models.py
+++ b/sagemaker_shim/models.py
@@ -263,12 +263,12 @@ async def upload_runtime_setup_result(
         digestmod=hashlib.sha256,
     ).hexdigest()
 
-    output_bucket_name = os.environ.get(
-        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME", ""
-    )
-    output_prefix = os.environ.get(
-        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", ""
-    )
+    output_bucket_name = os.environ[
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME"
+    ]
+    output_prefix = os.environ[
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX"
+    ]
 
     if output_prefix[-1] != "/":
         output_prefix += "/"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,6 +128,14 @@ def test_good_command_inference_from_task_list(local_s3, monkeypatch):
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_SET_EXTRA_GROUPS", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_USE_LINKED_INPUT", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_WRITABLE_DIRECTORIES", "")
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME",
+        local_s3.output_bucket_name,
+    )
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX",
+        f"runtime/{uuid4()}/",
+    )
 
     runner = CliRunner()
     runner.invoke(cli, ["invoke", "-t", json.dumps(tasks)])
@@ -172,6 +180,14 @@ def test_bad_command_inference_from_task_list(local_s3, monkeypatch):
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_SET_EXTRA_GROUPS", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_USE_LINKED_INPUT", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_WRITABLE_DIRECTORIES", "")
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME",
+        local_s3.output_bucket_name,
+    )
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX",
+        f"runtime/{uuid4()}/",
+    )
 
     runner = CliRunner()
     result = runner.invoke(cli, ["invoke", "-t", json.dumps(tasks)])
@@ -233,6 +249,14 @@ def test_good_command_inference_from_s3_uri(local_s3, monkeypatch):
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_SET_EXTRA_GROUPS", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_USE_LINKED_INPUT", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_WRITABLE_DIRECTORIES", "")
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME",
+        local_s3.output_bucket_name,
+    )
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX",
+        f"runtime/{uuid4()}/",
+    )
 
     definition_key = f"{uuid4()}/invocations.json"
 
@@ -293,6 +317,13 @@ def test_bad_command_inference_from_s3_uri(local_s3, monkeypatch):
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_SET_EXTRA_GROUPS", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_USE_LINKED_INPUT", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_WRITABLE_DIRECTORIES", "")
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME",
+        local_s3.output_bucket_name,
+    )
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", f"runtime/{pk1}/"
+    )
 
     definition_key = f"{uuid4()}/invocations.json"
 
@@ -361,6 +392,14 @@ def test_logging_setup(local_s3, monkeypatch):
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_SET_EXTRA_GROUPS", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_USE_LINKED_INPUT", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_WRITABLE_DIRECTORIES", "")
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME",
+        local_s3.output_bucket_name,
+    )
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX",
+        f"runtime/{uuid4()}/",
+    )
 
     runner = CliRunner()
     result = runner.invoke(cli, ["invoke", "-t", json.dumps(tasks)])
@@ -394,6 +433,14 @@ def test_logging_stderr_setup(local_s3, monkeypatch):
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_SET_EXTRA_GROUPS", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_USE_LINKED_INPUT", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_WRITABLE_DIRECTORIES", "")
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME",
+        local_s3.output_bucket_name,
+    )
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX",
+        f"runtime/{uuid4()}/",
+    )
 
     runner = CliRunner()
     result = runner.invoke(cli, ["invoke", "-t", json.dumps(tasks)])
@@ -487,6 +534,13 @@ def test_aux_data_failure(local_s3, monkeypatch, tmp_path):
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_USE_LINKED_INPUT", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_WRITABLE_DIRECTORIES", "")
     monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME",
+        local_s3.output_bucket_name,
+    )
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", f"runtime/{pk}/"
+    )
+    monkeypatch.setenv(
         "GRAND_CHALLENGE_COMPONENT_MODEL",
         f"s3://{local_s3.input_bucket_name}/{model_key}",
     )
@@ -510,6 +564,18 @@ def test_aux_data_failure(local_s3, monkeypatch, tmp_path):
         '"level": "ERROR", "source": "stderr", "internal": false, "task": null}'
     )
 
+    serialised_invocation = sync_s3_operation(
+        method=get_s3_file_content,
+        s3_uri=f"s3://{local_s3.output_bucket_name}/runtime/{pk}/.sagemaker_shim/runtime_setup_result.json",
+    )
+    parsed_result = json.loads(serialised_invocation)
+
+    assert parsed_result["return_code"] == 1
+    assert (
+        parsed_result["error_message"]
+        == "Could not set up model: Tarfile could not be extracted"
+    )
+
 
 def test_user_process_setup_failure(local_s3, mocker, monkeypatch, tmp_path):
     pk = str(uuid4())
@@ -529,6 +595,13 @@ def test_user_process_setup_failure(local_s3, mocker, monkeypatch, tmp_path):
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_SET_EXTRA_GROUPS", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_USE_LINKED_INPUT", "False")
     monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_WRITABLE_DIRECTORIES", "")
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME",
+        local_s3.output_bucket_name,
+    )
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", f"runtime/{pk}/"
+    )
     mocker.patch(
         "sagemaker_shim.models.UserProcess.setup",
         side_effect=UserSafeError("failure in user process setup"),
@@ -542,3 +615,52 @@ def test_user_process_setup_failure(local_s3, mocker, monkeypatch, tmp_path):
         '{"log": "failure in user process setup", '
         '"level": "ERROR", "source": "stderr", "internal": false, "task": null}'
     )
+
+    serialised_invocation = sync_s3_operation(
+        method=get_s3_file_content,
+        s3_uri=f"s3://{local_s3.output_bucket_name}/runtime/{pk}/.sagemaker_shim/runtime_setup_result.json",
+    )
+    parsed_result = json.loads(serialised_invocation)
+
+    assert parsed_result["return_code"] == 1
+    assert parsed_result["error_message"] == "failure in user process setup"
+
+
+def test_runtime_setup_result_written(local_s3, monkeypatch):
+    pk = str(uuid4())
+    tasks = [
+        {
+            "pk": pk,
+            "inputs": [],
+            "output_bucket_name": local_s3.output_bucket_name,
+            "output_prefix": f"tasks/{pk}",
+            "timeout": "PT10S",
+        }
+    ]
+
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_CMD_B64J",
+        encode_b64j(val=["echo", "hello"]),
+    )
+    monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_SET_EXTRA_GROUPS", "False")
+    monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_USE_LINKED_INPUT", "False")
+    monkeypatch.setenv("GRAND_CHALLENGE_COMPONENT_WRITABLE_DIRECTORIES", "")
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME",
+        local_s3.output_bucket_name,
+    )
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", f"runtime/{pk}/"
+    )
+
+    runner = CliRunner()
+    runner.invoke(cli, ["invoke", "-t", json.dumps(tasks)])
+
+    serialised_invocation = sync_s3_operation(
+        method=get_s3_file_content,
+        s3_uri=f"s3://{local_s3.output_bucket_name}/runtime/{pk}/.sagemaker_shim/runtime_setup_result.json",
+    )
+    parsed_result = json.loads(serialised_invocation)
+
+    assert parsed_result["return_code"] == 0
+    assert parsed_result["error_message"] == ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,6 @@ from click.testing import CliRunner
 from sagemaker_shim.cli import async_to_sync, cli
 from sagemaker_shim.exceptions import UserSafeError
 from sagemaker_shim.models import (
-    RuntimeSetupResult,
     S3Resources,
     get_s3_file_content,
     get_s3_resources,
@@ -651,7 +650,7 @@ def test_runtime_setup_result_written(local_s3, monkeypatch):
         local_s3.output_bucket_name,
     )
     monkeypatch.setenv(
-        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", f"runtime/{pk}"
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", f"runtime/{pk}/"
     )
 
     runner = CliRunner()
@@ -665,34 +664,3 @@ def test_runtime_setup_result_written(local_s3, monkeypatch):
 
     assert parsed_result["return_code"] == 0
     assert parsed_result["error_message"] == ""
-
-
-def test_runtime_setup_result(monkeypatch):
-    monkeypatch.setenv(
-        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME",
-        "some_bucket_name",
-    )
-    monkeypatch.setenv(
-        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", "some_prefix/"
-    )
-
-    runtime_setup_result = RuntimeSetupResult(return_code=0)
-
-    assert runtime_setup_result.return_code == 0
-    assert runtime_setup_result.error_message == ""
-    assert runtime_setup_result.output_bucket_name == "some_bucket_name"
-    assert runtime_setup_result.output_prefix == "some_prefix/"
-
-
-def test_runtime_setup_result_adds_forward_slash_to_prefix(monkeypatch):
-    monkeypatch.setenv(
-        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME",
-        "some_bucket_name",
-    )
-    monkeypatch.setenv(
-        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", "some_prefix"
-    )
-
-    runtime_setup_result = RuntimeSetupResult(return_code=0)
-
-    assert runtime_setup_result.output_prefix == "some_prefix/"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 from sagemaker_shim.cli import async_to_sync, cli
 from sagemaker_shim.exceptions import UserSafeError
 from sagemaker_shim.models import (
+    RuntimeSetupResult,
     S3Resources,
     get_s3_file_content,
     get_s3_resources,
@@ -650,7 +651,7 @@ def test_runtime_setup_result_written(local_s3, monkeypatch):
         local_s3.output_bucket_name,
     )
     monkeypatch.setenv(
-        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", f"runtime/{pk}/"
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", f"runtime/{pk}"
     )
 
     runner = CliRunner()
@@ -664,3 +665,34 @@ def test_runtime_setup_result_written(local_s3, monkeypatch):
 
     assert parsed_result["return_code"] == 0
     assert parsed_result["error_message"] == ""
+
+
+def test_runtime_setup_result(monkeypatch):
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME",
+        "some_bucket_name",
+    )
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", "some_prefix/"
+    )
+
+    runtime_setup_result = RuntimeSetupResult(return_code=0)
+
+    assert runtime_setup_result.return_code == 0
+    assert runtime_setup_result.error_message == ""
+    assert runtime_setup_result.output_bucket_name == "some_bucket_name"
+    assert runtime_setup_result.output_prefix == "some_prefix/"
+
+
+def test_runtime_setup_result_adds_forward_slash_to_prefix(monkeypatch):
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME",
+        "some_bucket_name",
+    )
+    monkeypatch.setenv(
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", "some_prefix"
+    )
+
+    runtime_setup_result = RuntimeSetupResult(return_code=0)
+
+    assert runtime_setup_result.output_prefix == "some_prefix/"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -200,9 +200,6 @@ def test_bad_command_inference_from_task_list(local_s3, monkeypatch):
 
     assert parsed_result["return_code"] == expected_return_code
     assert parsed_result["pk"] == pk1
-    assert (
-        parsed_result["error_message"] == "Process returned non-zero exit code"
-    )
 
     with pytest.raises(botocore.exceptions.ClientError) as error:
         sync_s3_operation(
@@ -352,9 +349,6 @@ def test_bad_command_inference_from_s3_uri(local_s3, monkeypatch):
 
     assert parsed_result["return_code"] == expected_return_code
     assert parsed_result["pk"] == pk1
-    assert (
-        parsed_result["error_message"] == "Process returned non-zero exit code"
-    )
 
     with pytest.raises(botocore.exceptions.ClientError) as error:
         sync_s3_operation(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -149,7 +149,7 @@ def test_good_command_inference_from_task_list(local_s3, monkeypatch):
 
         assert parsed_result["return_code"] == expected_return_code
         assert parsed_result["pk"] == pk
-        assert parsed_result["error_message"] == ""
+        assert parsed_result["user_safe_error_message"] == ""
 
 
 def test_bad_command_inference_from_task_list(local_s3, monkeypatch):
@@ -283,7 +283,7 @@ def test_good_command_inference_from_s3_uri(local_s3, monkeypatch):
 
         assert parsed_result["return_code"] == expected_return_code
         assert parsed_result["pk"] == pk
-        assert parsed_result["error_message"] == ""
+        assert parsed_result["user_safe_error_message"] == ""
 
 
 def test_bad_command_inference_from_s3_uri(local_s3, monkeypatch):
@@ -566,7 +566,7 @@ def test_aux_data_failure(local_s3, monkeypatch, tmp_path):
 
     assert parsed_result["return_code"] == 1
     assert (
-        parsed_result["error_message"]
+        parsed_result["user_safe_error_message"]
         == "Could not set up model: Tarfile could not be extracted"
     )
 
@@ -617,7 +617,10 @@ def test_user_process_setup_failure(local_s3, mocker, monkeypatch, tmp_path):
     parsed_result = json.loads(serialised_invocation)
 
     assert parsed_result["return_code"] == 1
-    assert parsed_result["error_message"] == "failure in user process setup"
+    assert (
+        parsed_result["user_safe_error_message"]
+        == "failure in user process setup"
+    )
 
 
 def test_runtime_setup_result_written(local_s3, monkeypatch):
@@ -657,4 +660,4 @@ def test_runtime_setup_result_written(local_s3, monkeypatch):
     parsed_result = json.loads(serialised_invocation)
 
     assert parsed_result["return_code"] == 0
-    assert parsed_result["error_message"] == ""
+    assert parsed_result["user_safe_error_message"] == ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -507,8 +507,7 @@ def test_aux_data_failure(local_s3, monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert result.stderr.splitlines()[-1] == (
         '{"log": "Could not set up model: Tarfile could not be extracted", '
-        '"level": "ERROR", "source": "stderr", "internal": false, '
-        '"task": null, "inference_result_skipped": true}'
+        '"level": "ERROR", "source": "stderr", "internal": false, "task": null}'
     )
 
 
@@ -541,6 +540,5 @@ def test_user_process_setup_failure(local_s3, mocker, monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert result.stderr.splitlines()[-1] == (
         '{"log": "failure in user process setup", '
-        '"level": "ERROR", "source": "stderr", "internal": false, '
-        '"task": null, "inference_result_skipped": true}'
+        '"level": "ERROR", "source": "stderr", "internal": false, "task": null}'
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,6 +141,7 @@ def test_good_command_inference_from_task_list(local_s3, monkeypatch):
 
         assert parsed_result["return_code"] == expected_return_code
         assert parsed_result["pk"] == pk
+        assert parsed_result["error_message"] == ""
 
 
 def test_bad_command_inference_from_task_list(local_s3, monkeypatch):
@@ -183,6 +184,9 @@ def test_bad_command_inference_from_task_list(local_s3, monkeypatch):
 
     assert parsed_result["return_code"] == expected_return_code
     assert parsed_result["pk"] == pk1
+    assert (
+        parsed_result["error_message"] == "Process returned non-zero exit code"
+    )
 
     with pytest.raises(botocore.exceptions.ClientError) as error:
         sync_s3_operation(
@@ -258,6 +262,7 @@ def test_good_command_inference_from_s3_uri(local_s3, monkeypatch):
 
         assert parsed_result["return_code"] == expected_return_code
         assert parsed_result["pk"] == pk
+        assert parsed_result["error_message"] == ""
 
 
 def test_bad_command_inference_from_s3_uri(local_s3, monkeypatch):
@@ -316,6 +321,9 @@ def test_bad_command_inference_from_s3_uri(local_s3, monkeypatch):
 
     assert parsed_result["return_code"] == expected_return_code
     assert parsed_result["pk"] == pk1
+    assert (
+        parsed_result["error_message"] == "Process returned non-zero exit code"
+    )
 
     with pytest.raises(botocore.exceptions.ClientError) as error:
         sync_s3_operation(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -650,7 +650,7 @@ def test_runtime_setup_result_written(local_s3, monkeypatch):
         local_s3.output_bucket_name,
     )
     monkeypatch.setenv(
-        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", f"runtime/{pk}/"
+        "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX", f"runtime/{pk}"
     )
 
     runner = CliRunner()

--- a/tests/test_container_image.py
+++ b/tests/test_container_image.py
@@ -76,6 +76,12 @@ def _container(*, base_image="ubuntu:latest", host_port=8080, cmd=None):
             container_env = copy.deepcopy(local_s3.env)
 
             container_env["AWS_S3_ENDPOINT_URL"] = "http://local-s3:8333"
+            container_env[
+                "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_BUCKET_NAME"
+            ] = local_s3.output_bucket_name
+            container_env[
+                "GRAND_CHALLENGE_COMPONENT_RUNTIME_OUTPUT_PREFIX"
+            ] = "test/"
 
             container = client.containers.run(
                 image=new_tag,

--- a/uv.lock
+++ b/uv.lock
@@ -775,7 +775,6 @@ dependencies = [
     { name = "botocore" },
     { name = "click" },
     { name = "fastapi" },
-    { name = "setuptools" },
     { name = "uvicorn" },
 ]
 
@@ -791,6 +790,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-randomly" },
     { name = "pytest-xdist" },
+    { name = "setuptools" },
     { name = "staticx", marker = "sys_platform == 'linux'" },
     { name = "types-aioboto3", extra = ["s3"] },
     { name = "types-aiofiles" },
@@ -802,7 +802,6 @@ requires-dist = [
     { name = "botocore" },
     { name = "click" },
     { name = "fastapi", specifier = "!=0.89.0" },
-    { name = "setuptools", specifier = "<81" },
     { name = "uvicorn" },
 ]
 
@@ -818,6 +817,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-randomly" },
     { name = "pytest-xdist" },
+    { name = "setuptools", specifier = "<81" },
     { name = "staticx", marker = "sys_platform == 'linux'" },
     { name = "types-aioboto3", extras = ["s3"] },
     { name = "types-aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -768,7 +768,7 @@ wheels = [
 
 [[package]]
 name = "sagemaker-shim"
-version = "0.8.0"
+version = "0.8.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },

--- a/uv.lock
+++ b/uv.lock
@@ -768,7 +768,7 @@ wheels = [
 
 [[package]]
 name = "sagemaker-shim"
-version = "0.6.1"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
Remove the need to parse the logs to handle failures and allow to postpone logs collection by:
- adding the error message directly to the inference result
- replacing the structured log message `inference_result_skipped` with a runtime setup result file written to s3