### PR TITLE
Adjust OOM score of child processes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "botocore",
 ]
 name = "sagemaker-shim"
-version = "0.8.1"
+version = "0.9.0"
 description = "Adapts algorithms that implement the Grand Challenge inference API for running in SageMaker"
 readme = "README.md"
 classifiers = [

--- a/sagemaker_shim/models.py
+++ b/sagemaker_shim/models.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel, ConfigDict, RootModel, field_validator
 from sagemaker_shim.exceptions import UserSafeError
 from sagemaker_shim.extract import safe_extract
 from sagemaker_shim.logging import STDOUT_LEVEL
+from sagemaker_shim.oom import make_child_oom_preexec_fn
 
 if TYPE_CHECKING:
     from _typeshed import StrOrBytesPath  # pragma: no cover
@@ -867,6 +868,7 @@ class UserProcess(ProcUserMixin):
                 # The following should always be set to protect this environment
                 shell=False,
                 close_fds=True,
+                preexec_fn=make_child_oom_preexec_fn(),
             )
         except PermissionError as error:
             raise UserSafeError(

--- a/sagemaker_shim/oom.py
+++ b/sagemaker_shim/oom.py
@@ -1,0 +1,31 @@
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+OOM_SCORE_ADJ_MAX = 1000
+
+
+def make_child_oom_preexec_fn() -> Callable[[], None]:
+    """Return a preexec_fn that makes the child the preferred OOM kill target.
+
+    This runs in the child process after fork() but before exec().
+    Setting oom_score_adj to the maximum value (1000) ensures the kernel's
+    OOM killer will prefer killing this process (and its descendants) over
+    the parent sagemaker-shim process when the container's memory limit
+    is reached.
+
+    This value is inherited by any grandchild processes.
+    """
+
+    def _adjust_oom_score() -> None:
+        try:
+            Path(f"/proc/{os.getpid()}/oom_score_adj").write_text(
+                str(OOM_SCORE_ADJ_MAX)
+            )
+        except OSError:
+            # Non-fatal: we may not be on Linux or lack permissions.
+            # Logging is not safe in preexec_fn (runs post-fork),
+            # so we silently ignore.
+            pass
+
+    return _adjust_oom_score

--- a/tests/test_oom.py
+++ b/tests/test_oom.py
@@ -1,0 +1,80 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from sagemaker_shim.oom import OOM_SCORE_ADJ_MAX, make_child_oom_preexec_fn
+
+
+def test_make_child_oom_preexec_fn_writes_oom_score_adj(tmp_path):
+    """The preexec_fn writes the max OOM score to the process's
+    oom_score_adj file."""
+    fake_proc_path = tmp_path / "oom_score_adj"
+    fake_proc_path.write_text("0")
+
+    preexec_fn = make_child_oom_preexec_fn()
+
+    with patch(
+        "sagemaker_shim.oom.Path",
+        side_effect=lambda p: (
+            fake_proc_path if "oom_score_adj" in str(p) else Path(p)
+        ),
+    ):
+        preexec_fn()
+
+    assert fake_proc_path.read_text() == str(OOM_SCORE_ADJ_MAX)
+
+
+def test_make_child_oom_preexec_fn_constructs_correct_path():
+    """The preexec_fn targets /proc/<pid>/oom_score_adj."""
+    preexec_fn = make_child_oom_preexec_fn()
+
+    with patch("sagemaker_shim.oom.Path") as mock_path:
+        mock_path.return_value.write_text = lambda _: None
+        preexec_fn()
+
+    mock_path.assert_called_once_with(f"/proc/{os.getpid()}/oom_score_adj")
+
+
+def test_make_child_oom_preexec_fn_handles_oserror_gracefully(tmp_path):
+    """The preexec_fn silently handles OSError (e.g. not on Linux)."""
+    preexec_fn = make_child_oom_preexec_fn()
+
+    with patch("sagemaker_shim.oom.Path") as mock_path:
+        mock_path.return_value.write_text.side_effect = OSError(
+            "Permission denied"
+        )
+        # Should not raise
+        preexec_fn()
+
+
+def test_make_child_oom_preexec_fn_returns_callable():
+    """make_child_oom_preexec_fn returns a callable with no arguments."""
+    preexec_fn = make_child_oom_preexec_fn()
+    assert callable(preexec_fn)
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/oom_score_adj").exists(),
+    reason="oom_score_adj not available (not Linux)",
+)
+def test_make_child_oom_preexec_fn_integration():
+    """Integration test: verify the function writes to the real procfs
+    when running on Linux."""
+    preexec_fn = make_child_oom_preexec_fn()
+
+    # Read the current value to restore after test
+    oom_path = Path(f"/proc/{os.getpid()}/oom_score_adj")
+    original_value = oom_path.read_text().strip()
+
+    try:
+        preexec_fn()
+        new_value = oom_path.read_text().strip()
+        assert new_value == str(OOM_SCORE_ADJ_MAX)
+    finally:
+        # Restore original value
+        try:
+            oom_path.write_text(original_value)
+        except OSError:
+            pass


### PR DESCRIPTION
This should get the kernel to target child processes (the user's process and its children) for OOM killing, so that SageMaker Shim can then exit cleanly.

See https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/857